### PR TITLE
Add handling for unsupported cards

### DIFF
--- a/HidProxWeigand.cpp
+++ b/HidProxWeigand.cpp
@@ -84,7 +84,8 @@ void HidProxWeigandClass::loop() {
             }
         }
 
-        // If we have bits and we the weigand counter went out.
+        // If we have bits and the weigand counter went out.
+        bool unsupported = false;
         if ((this->_currentReader->bitCount > 0) && (this->_currentReader->flagDone)) {
             uint8_t facStartBit = 0;
             uint8_t facStopBit = 0;
@@ -112,23 +113,28 @@ void HidProxWeigandClass::loop() {
             }
             else {
                 // Unrecognized format.
-                // TODO what to do here?
+                unsupported = true;
+
+                // TODO add support for more card formats.
             }
 
-            // Get the facility code.
-            uint8_t i = 0;
-            for (i = facStartBit; i < facStopBit; i++) {
-                this->_currentReader->facilityCode <<= 1;
-                this->_currentReader->facilityCode |= this->_currentReader->databits[i];
-            }
+            if (!unsupported) {
+                // Get the facility code.
+                uint8_t i = 0;
+                for (i = facStartBit; i < facStopBit; i++) {
+                    this->_currentReader->facilityCode <<= 1;
+                    this->_currentReader->facilityCode |= this->_currentReader->databits[i];
+                }
 
-            // Get the card code.
-            for (i = cardStartBit; i < cardStopBit; i++) {
-                this->_currentReader->cardCode <<= 1;
-                this->_currentReader->cardCode |= this->_currentReader->databits[i];
+                // Get the card code.
+                for (i = cardStartBit; i < cardStopBit; i++) {
+                    this->_currentReader->cardCode <<= 1;
+                    this->_currentReader->cardCode |= this->_currentReader->databits[i];
+                }
             }
 
             // Fire the event if we have a handler callback.
+            this->_currentReader->cardUnsupported = unsupported;
             if (this->_currentReader->onCardRead != NULL) {
                 this->_currentReader->onCardRead(this->_currentReader);
             }

--- a/HidProxWeigand.cpp
+++ b/HidProxWeigand.cpp
@@ -118,9 +118,9 @@ void HidProxWeigandClass::loop() {
                 // TODO add support for more card formats.
             }
 
+            uint8_t i = 0;
             if (!unsupported) {
                 // Get the facility code.
-                uint8_t i = 0;
                 for (i = facStartBit; i < facStopBit; i++) {
                     this->_currentReader->facilityCode <<= 1;
                     this->_currentReader->facilityCode |= this->_currentReader->databits[i];

--- a/HidProxWeigand.h
+++ b/HidProxWeigand.h
@@ -65,6 +65,11 @@ struct ProxReaderInfo {
     bool flagDone;
 
     /**
+     * Flag to indicate that the card read is of an unsupported format.
+     */
+    bool cardUnsupported;
+
+    /**
      * The facility code. Will be zero unless a valid code is read.
      */
     unsigned long facilityCode;
@@ -119,6 +124,7 @@ struct ProxReaderInfo {
     ProxReaderInfo() {
         onCardRead = NULL;
         flagDone = false;
+        unsupported = false;
         facilityCode = 0;
         cardCode = 0;
         bitCount = 0;
@@ -127,7 +133,8 @@ struct ProxReaderInfo {
 };
 
 /**
- * [HidProxWeigandClass description]
+ * HID card reader manager class. Provides facilities for adding card readers
+ * and processing card reads.
  */
 class HidProxWeigandClass {
 public:

--- a/HidProxWeigand.h
+++ b/HidProxWeigand.h
@@ -124,7 +124,7 @@ struct ProxReaderInfo {
     ProxReaderInfo() {
         onCardRead = NULL;
         flagDone = false;
-        unsupported = false;
+        cardUnsupported = false;
         facilityCode = 0;
         cardCode = 0;
         bitCount = 0;

--- a/examples/AdvancedExample/AdvancedExample.ino
+++ b/examples/AdvancedExample/AdvancedExample.ino
@@ -26,7 +26,7 @@
  #define PIN_RDR2_RED_LED 11
 
  ProxReaderInfo* reader1;   // Card reader 1.
- ProxReaderInfo* reader2;
+ ProxReaderInfo* reader2;   // Card reader 2.
 
  // Callback for handling card reads from reader 1.
  void cardRead1Handler(ProxReaderInfo* reader) {


### PR DESCRIPTION
Adding handling for unsupported cards. Now when an unrecognized card is
read, a flag is set in the ProxReaderInfo structure to indicate the
card format is unsupported.