### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,24 +5,24 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-HidProxWeigand  KEYWORD1
-ProxReaderInfo  KEYWORD1
+HidProxWeigand	KEYWORD1
+ProxReaderInfo	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-addReader   KEYWORD2
-getCurrentReader    KEYWORD2
-loop    KEYWORD2
-ISR_Data0   KEYWORD2
-ISR_Data1   KEYWORD2
-HidProxWeigand_AttachReaderInterrupts   KEYWORD2
+addReader	KEYWORD2
+getCurrentReader	KEYWORD2
+loop	KEYWORD2
+ISR_Data0	KEYWORD2
+ISR_Data1	KEYWORD2
+HidProxWeigand_AttachReaderInterrupts	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-MAX_READ_BITS   LITERAL1
-WEIGAND_WAIT_TIME   LITERAL1
-CARD_FORMAT_CORPORATE_1000  LITERAL1
-CARD_FORMAT_WEIGAND_26  LITERAL1
-SUPPORTED_READERS   LITERAL1
+MAX_READ_BITS	LITERAL1
+WEIGAND_WAIT_TIME	LITERAL1
+CARD_FORMAT_CORPORATE_1000	LITERAL1
+CARD_FORMAT_WEIGAND_26	LITERAL1
+SUPPORTED_READERS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords