### PR TITLE
Fix typos in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ void setup() {
     }
 
     // Create the reader and attach it to the system.
-    reader1 = HidProxWeigand.addReader(PIN_DATA0, PIN_DATA1, cardReadHandler);
+    reader1 = HidProxWiegand.addReader(PIN_DATA0, PIN_DATA1, cardReadHandler);
 
     // Attach interrupt handlers for reader 1.
     HidProxWiegand_AttachReaderInterrupts(PIN_DATA0, PIN_DATA1, handleInterrupt0, handleInterrupt1);
@@ -105,7 +105,7 @@ void setup() {
 
 void loop() {
     // Process any cards that have been read.
-    HidProxWeigand.loop();
+    HidProxWiegand.loop();
 }
 ```
 


### PR DESCRIPTION
Great lib! Works great for me, but the example code doesnt compile due to this typo.

I think the whole project is technically incorrectly spelled, but I like it anyways!